### PR TITLE
feat(app): match S3 origins with regional endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
           pytest --junitxml=pytest.xml --cov=rewind_connect tests/test*.py | tee pytest-coverage.txt
 
       - name: Comment coverage
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: MishaKav/pytest-coverage-comment@dd5b80bde6d16941f336518e92929e89069d8451 # v1.7.2
         with:
           pytest-coverage-path: ./pytest-coverage.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3
 pytest
 pytest-cov 
-moto
+moto<5.2
 black

--- a/src/app.py
+++ b/src/app.py
@@ -9,7 +9,10 @@ cloudfront_client = boto3.client("cloudfront")
 
 def get_cloudfront_distribution_id(bucket):
 
-    bucket_origin = bucket + ".s3.amazonaws.com"
+    bucket_origins = {bucket + ".s3.amazonaws.com"}
+    region = boto3.session.Session().region_name
+    if region:
+        bucket_origins.add(bucket + ".s3." + region + ".amazonaws.com")
     cf_distro_id = None
 
     # Create a reusable Paginator
@@ -22,7 +25,7 @@ def get_cloudfront_distribution_id(bucket):
         for distribution in page["DistributionList"]["Items"]:
             for cf_origin in distribution["Origins"]["Items"]:
                 print("Origin found {}".format(cf_origin["DomainName"]))
-                if bucket_origin == cf_origin["DomainName"]:
+                if cf_origin["DomainName"] in bucket_origins:
                     cf_distro_id = distribution["Id"]
                     print(
                         "The CF distribution ID for {} is {}".format(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -71,6 +71,52 @@ def s3_and_cloudfront_setup(mock_s3, mock_cloudfront):
     yield bucket_name, "test-key"
 
 
+@pytest.fixture
+def s3_and_cloudfront_regional_setup(mock_s3, mock_cloudfront, monkeypatch):
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "eu-west-1")
+    monkeypatch.setenv("AWS_REGION", "eu-west-1")
+
+    bucket_name = "test-bucket-regional"
+    mock_s3.create_bucket(
+        Bucket=bucket_name,
+        CreateBucketConfiguration={"LocationConstraint": "eu-west-1"},
+    )
+    mock_s3.put_object(Bucket=bucket_name, Key="test-key", Body="test-content")
+
+    distribution_config = {
+        "CallerReference": "test-distribution-regional",
+        "Comment": "Test distribution regional",
+        "Origins": {
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "S3-test-bucket-regional",
+                    "DomainName": f"{bucket_name}.s3.eu-west-1.amazonaws.com",
+                    "OriginPath": "",
+                    "CustomHeaders": {"Quantity": 0},
+                    "S3OriginConfig": {"OriginAccessIdentity": ""},
+                }
+            ],
+        },
+        "DefaultCacheBehavior": {
+            "TargetOriginId": "S3-test-bucket-regional",
+            "ViewerProtocolPolicy": "allow-all",
+            "TrustedSigners": {"Enabled": False, "Quantity": 0},
+            "ForwardedValues": {
+                "QueryString": False,
+                "Cookies": {"Forward": "none"},
+                "Headers": {"Quantity": 0},
+                "QueryStringCacheKeys": {"Quantity": 0},
+            },
+            "MinTTL": 0,
+        },
+        "Enabled": True,
+    }
+    mock_cloudfront.create_distribution(DistributionConfig=distribution_config)
+
+    yield bucket_name, "test-key"
+
+
 def test_lambda_handler_happy_path(s3_and_cloudfront_setup, mock_cloudfront):
     bucket_name, key = s3_and_cloudfront_setup
 
@@ -84,4 +130,18 @@ def test_lambda_handler_happy_path(s3_and_cloudfront_setup, mock_cloudfront):
         response = lambda_handler(event, None)
 
     # Assertions
+    assert response == "Success"
+
+
+def test_lambda_handler_regional_origin(
+    s3_and_cloudfront_regional_setup, mock_cloudfront
+):
+    bucket_name, key = s3_and_cloudfront_regional_setup
+
+    event = {
+        "Records": [{"s3": {"bucket": {"name": bucket_name}, "object": {"key": key}}}]
+    }
+    with patch("src.app.cloudfront_client", mock_cloudfront):
+        response = lambda_handler(event, None)
+
     assert response == "Success"


### PR DESCRIPTION
Also accept `<bucket>.s3.<region>.amazonaws.com` when looking up the CloudFront distribution, so buckets created in regions that use the regional virtual-hosted endpoint are recognized.