### PR TITLE
fix(app): invalidate all distributions matching a bucket

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -7,13 +7,13 @@ import time
 cloudfront_client = boto3.client("cloudfront")
 
 
-def get_cloudfront_distribution_id(bucket):
+def get_cloudfront_distribution_ids(bucket):
 
     bucket_origins = {bucket + ".s3.amazonaws.com"}
     region = boto3.session.Session().region_name
     if region:
         bucket_origins.add(bucket + ".s3." + region + ".amazonaws.com")
-    cf_distro_id = None
+    cf_distro_ids = []
 
     # Create a reusable Paginator
     paginator = cloudfront_client.get_paginator("list_distributions")
@@ -26,14 +26,15 @@ def get_cloudfront_distribution_id(bucket):
             for cf_origin in distribution["Origins"]["Items"]:
                 print("Origin found {}".format(cf_origin["DomainName"]))
                 if cf_origin["DomainName"] in bucket_origins:
-                    cf_distro_id = distribution["Id"]
+                    cf_distro_ids.append(distribution["Id"])
                     print(
                         "The CF distribution ID for {} is {}".format(
-                            bucket, cf_distro_id
+                            bucket, distribution["Id"]
                         )
                     )
+                    break
 
-    return cf_distro_id
+    return cf_distro_ids
 
 
 # --------------- Main handler ------------------
@@ -51,37 +52,38 @@ def lambda_handler(event, context):
     if not key.startswith("/"):
         key = "/" + key
 
-    cf_distro_id = get_cloudfront_distribution_id(bucket)
+    cf_distro_ids = get_cloudfront_distribution_ids(bucket)
 
-    if cf_distro_id:
-        print(
-            "Creating invalidation for {} on Cloudfront distribution {}".format(
-                key, cf_distro_id
-            )
-        )
-
-        try:
-            invalidation = cloudfront_client.create_invalidation(
-                DistributionId=cf_distro_id,
-                InvalidationBatch={
-                    "Paths": {"Quantity": 1, "Items": [key]},
-                    "CallerReference": str(time.time()),
-                },
-            )
-
+    if cf_distro_ids:
+        for cf_distro_id in cf_distro_ids:
             print(
-                "Submitted invalidation. ID {} Status {}".format(
-                    invalidation["Invalidation"]["Id"],
-                    invalidation["Invalidation"]["Status"],
+                "Creating invalidation for {} on Cloudfront distribution {}".format(
+                    key, cf_distro_id
                 )
             )
-        except Exception as e:
-            print(
-                "Error processing object {} from bucket {}. Event {}".format(
-                    key, bucket, json.dumps(event, indent=2)
+
+            try:
+                invalidation = cloudfront_client.create_invalidation(
+                    DistributionId=cf_distro_id,
+                    InvalidationBatch={
+                        "Paths": {"Quantity": 1, "Items": [key]},
+                        "CallerReference": str(time.time()),
+                    },
                 )
-            )
-            raise e
+
+                print(
+                    "Submitted invalidation. ID {} Status {}".format(
+                        invalidation["Invalidation"]["Id"],
+                        invalidation["Invalidation"]["Status"],
+                    )
+                )
+            except Exception:
+                print(
+                    "Error processing object {} from bucket {} on distribution {}. Event {}".format(
+                        key, bucket, cf_distro_id, json.dumps(event, indent=2)
+                    )
+                )
+                raise
     else:
         print(
             "Bucket {} does not appeaer to be an origin for a Cloudfront distribution".format(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -145,3 +145,70 @@ def test_lambda_handler_regional_origin(
         response = lambda_handler(event, None)
 
     assert response == "Success"
+
+
+def _make_distribution_config(bucket_name, caller_reference):
+    return {
+        "CallerReference": caller_reference,
+        "Comment": caller_reference,
+        "Origins": {
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": f"S3-{bucket_name}",
+                    "DomainName": f"{bucket_name}.s3.amazonaws.com",
+                    "OriginPath": "",
+                    "CustomHeaders": {"Quantity": 0},
+                    "S3OriginConfig": {"OriginAccessIdentity": ""},
+                }
+            ],
+        },
+        "DefaultCacheBehavior": {
+            "TargetOriginId": f"S3-{bucket_name}",
+            "ViewerProtocolPolicy": "allow-all",
+            "TrustedSigners": {"Enabled": False, "Quantity": 0},
+            "ForwardedValues": {
+                "QueryString": False,
+                "Cookies": {"Forward": "none"},
+                "Headers": {"Quantity": 0},
+                "QueryStringCacheKeys": {"Quantity": 0},
+            },
+            "MinTTL": 0,
+        },
+        "Enabled": True,
+    }
+
+
+def test_lambda_handler_invalidates_all_matching_distributions(
+    mock_s3, mock_cloudfront
+):
+    bucket_name = "shared-origin-bucket"
+    mock_s3.create_bucket(Bucket=bucket_name)
+    mock_s3.put_object(Bucket=bucket_name, Key="test-key", Body="test-content")
+
+    expected_distribution_ids = set()
+    for caller_ref in ("dist-a", "dist-b"):
+        result = mock_cloudfront.create_distribution(
+            DistributionConfig=_make_distribution_config(bucket_name, caller_ref)
+        )
+        expected_distribution_ids.add(result["Distribution"]["Id"])
+
+    event = {
+        "Records": [
+            {"s3": {"bucket": {"name": bucket_name}, "object": {"key": "test-key"}}}
+        ]
+    }
+    with patch("src.app.cloudfront_client", mock_cloudfront):
+        response = lambda_handler(event, None)
+
+    assert response == "Success"
+
+    invalidated_distribution_ids = set()
+    for distribution_id in expected_distribution_ids:
+        invalidations = mock_cloudfront.list_invalidations(
+            DistributionId=distribution_id
+        )["InvalidationList"].get("Items", [])
+        if invalidations:
+            invalidated_distribution_ids.add(distribution_id)
+
+    assert invalidated_distribution_ids == expected_distribution_ids


### PR DESCRIPTION
Previously the lookup overwrote `cf_distro_id` on every match, so when a bucket was configured as the origin of more than one CloudFront distribution only the last one encountered during pagination got an invalidation. Collect all matching distribution IDs and create an invalidation against each.