### PR TITLE
ci: split lint/test into parallel jobs and fix coverage path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Format
+        uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # stable
+
   test:
     runs-on: ubuntu-latest
     permissions:
@@ -18,15 +25,12 @@ jobs:
 
       - run: pip install -r requirements.txt
 
-      - name: Format
-        uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # stable
-
       - name: Unit Tests
         env:
           PYTHONPATH: .
         run: |
           set -o pipefail
-          pytest --junitxml=pytest.xml --cov=rewind_connect tests/test*.py | tee pytest-coverage.txt
+          pytest --junitxml=pytest.xml --cov=src tests/test*.py | tee pytest-coverage.txt
 
       - name: Comment coverage
         if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
## Summary

- Splits the single CI job into `lint` (checkout + black) and `test` (pytest + coverage) so they run in parallel. Lint signal lands without waiting on the Python toolchain.
- Fixes `--cov=rewind_connect` → `--cov=src`. The previous package name didn't match anything in this repo (source lives in `src/`), so the coverage comment posted on every PR has been reporting 0% indefinitely.

## Test plan

- [x] `pytest --cov=src tests/` locally reports real numbers (90% on a fresh clone of `main`)
- [ ] Both `lint` and `test` checks pass on this PR
- [ ] Coverage comment lands on this PR with non-zero numbers