### PR TITLE
chore: update CODEOWNERS team refs to rewind-community

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, members of
-# @rewindio/codeowners will be requested for review when someone
+# @rewind-community/codeowners will be requested for review when someone
 # opens a pull request.
-*       @rewindio/devops
+*       @rewind-community/devops


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community` as part of the OSS classification cleanup. The `.github/CODEOWNERS` file still references `@rewindio/devops`; GitHub silently drops cross-org team references when evaluating CODEOWNERS, so codeowner auto-assign + required-approver-from-codeowners has been effectively disabled since the move. Updating the slug to `@rewind-community/devops` restores the intended behavior.

## Related PRs

- rewindio/terraform-rewindio-github#365 (terraform side of the move)

## Testing Performed

Team `rewind-community/devops` exists and was confirmed via `gh api orgs/rewind-community/teams/devops`. Visual diff review.